### PR TITLE
Make deepEqual configurable via difflet(options).

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,6 +74,9 @@ If `opts.comma === 'first'` then commas will be placed at the start of lines.
 Setting `opts.comment` to `true` will turn on comments with the previous
 contents like this:
 
+Setting `opts.deepEqual` allows a different equality function to be used. By default
+[deep-is](https://npmjs.org/package/deep-is) is used.
+
 ![object comments](http://substack.net/images/screenshots/difflet_object_comments.png)
 
 diff(prev, next)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var traverse = require('traverse');
 var Stream = require('stream').Stream;
 var charm = require('charm');
-var deepEqual = require('deep-is');
 
 var exports = module.exports = function (opts_) {
     var fn = difflet.bind(null, opts_);
@@ -35,8 +34,10 @@ function difflet (opts, prev, next) {
         stream.write = function (buf) { this.emit('data', buf) };
         stream.end = function () { this.emit('end') };
     }
-    
     if (!opts) opts = {};
+
+    var deepEqual = opts.deepEqual || require('deep-is');
+
     if (opts.start === undefined && opts.stop === undefined) {
         var c = charm(stream);
         opts.start = function (type) {


### PR DESCRIPTION
This makes it possible to swap out the deepEqual function used internally via the options passed to difflet.  I needed to do this in order to use a deepEqual that didn't coerce strings/numbers.