### PR TITLE
Added support for comparing content of nested arrays

### DIFF
--- a/example/deep_array.js
+++ b/example/deep_array.js
@@ -1,0 +1,23 @@
+var difflet = require('../');
+var subjectA = {
+  levelOne: {
+    levelTwo: {
+      array: ['a', 'b', 3]
+    }
+  }
+};
+
+var subjectB = {
+  levelOne: {
+    levelTwo: {
+      array: []
+    }
+  }
+};
+
+var s = difflet({ indent : 2, comment : true }).compare(
+    subjectA,
+    subjectB
+);
+process.stdout.write("DIFFLET:");
+process.stdout.write(s);

--- a/index.js
+++ b/index.js
@@ -79,6 +79,12 @@ function difflet (opts, prev, next) {
     function stringifier (insertable, node, opts) {
         var indent = opts.indent;
         
+        var writeObj = function(obj) {
+            traverse(obj).forEach(function (x) {
+                plainStringify.call(this, x, { indent : indent });
+            });
+        };
+
         if (insertable) {
             var prevNode = traverse.get(prev, this.path || []);
         }
@@ -106,6 +112,18 @@ function difflet (opts, prev, next) {
                 indent = 0;
             }
             
+            if (Array.isArray(prevNode) && node.length != prevNode.length && node.length == 0) {
+                write('[\n');
+
+                set('deleted');
+                prevNode.forEach(function(obj, i) {
+                    if(i != 0) write(', ');
+                    writeObj(obj);
+                });
+                unset('deleted');
+                return write(indentx + '\n]');
+            }
+
             this.before(function () {
                 if (inserted) set('inserted');
                 if (indent && commaFirst) {
@@ -134,9 +152,7 @@ function difflet (opts, prev, next) {
                 ) {
                     set('comment');
                     write(' // != ');
-                    traverse(prev).forEach(function (x) {
-                        plainStringify.call(this, x, { indent : 0 });
-                    });
+                    traverse(prev).forEach(writeObj);
                     unset('comment');
                 }
                 
@@ -148,6 +164,19 @@ function difflet (opts, prev, next) {
                         write('\n' + indentx);
                     }
                 }
+                else {
+                    if(prevNode && prevNode.length > child.parent.node.length) {
+                        var missingItems = prevNode.slice(child.key + 1);
+
+                        set('deleted');
+                        missingItems.forEach(function(item) {
+                            write(', ');
+                            writeObj(item);
+                        });
+                        unset('deleted');
+                    }
+                }
+
             });
             
             this.after(function () {

--- a/test/object_tests.js
+++ b/test/object_tests.js
@@ -1,0 +1,72 @@
+var difflet = require('../');
+var diff = difflet();
+var test = require('tap').test;
+
+test('diffing with empty nested array', function (t) {
+  t.plan(1);
+
+  var subjectA = {
+    levelOne: {
+      levelTwo: {
+        array: ['a', 'b', 3]
+      }
+    }
+  };
+
+  var subjectB = {
+    levelOne: {
+      levelTwo: {
+        array: []
+      }
+    }
+  };
+
+  var d = diff.compare(subjectA, subjectB);
+  t.equal(d, "{\"levelOne\":{\"levelTwo\":{\"array\":[\n\u001b[31m\u001b[1m\"a\", \"b\", 3\u001b[0m\n]}}}");
+});
+
+test('diffing nested array with missing values', function (t) {
+  t.plan(1);
+
+  var subjectA = {
+    levelOne: {
+      levelTwo: {
+        array: ['a', 'b', 3]
+      }
+    }
+  };
+
+  var subjectB = {
+    levelOne: {
+      levelTwo: {
+        array: ['a']
+      }
+    }
+  };
+
+  var d = diff.compare(subjectA, subjectB);
+  t.equal(d, "{\"levelOne\":{\"levelTwo\":{\"array\":[\"a\"\u001b[31m\u001b[1m, \"b\", 3\u001b[0m]}}}");
+});
+
+test('diffing nested array with added values', function (t) {
+  t.plan(1);
+
+  var subjectA = {
+    levelOne: {
+      levelTwo: {
+        array: ['a']
+      }
+    }
+  };
+
+  var subjectB = {
+    levelOne: {
+      levelTwo: {
+        array: ['a', 'b', 3]
+      }
+    }
+  };
+
+  var d = diff.compare(subjectA, subjectB);
+  t.equal(d, "{\"levelOne\":{\"levelTwo\":{\"array\":[\"a\",\u001b[32m\u001b[1m\"b\"\u001b[0m,\u001b[32m\u001b[1m3\u001b[0m]}}}");
+});

--- a/test/object_tests.js
+++ b/test/object_tests.js
@@ -66,7 +66,7 @@ test('diffing nested array with added values', function (t) {
       }
     }
   };
-
+  
   var d = diff.compare(subjectA, subjectB);
   t.equal(d, "{\"levelOne\":{\"levelTwo\":{\"array\":[\"a\",\u001b[32m\u001b[1m\"b\"\u001b[0m,\u001b[32m\u001b[1m3\u001b[0m]}}}");
 });


### PR DESCRIPTION
When comparing two objects with nested arrays, difflet fails to detail differences if the comparison objects array is empty.. ie:

```
  var subjectA = {
    levelOne: {
      levelTwo: {
        array: ['a', 'b', 3]
      }
    }
  };

  var subjectB = {
    levelOne: {
      levelTwo: {
        array: []
      }
    }
  };

diff.compare(subjectA, subjectB); // No diffs reported
```

This pull requests lists the missing elements if any elements are missing from the source, or comparison object's arrays